### PR TITLE
Add PostgreSQL DB for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - psql -U postgres --list
   - psql -d SemStew -f database/create_SemStew_Database.sql -U postgres
   - psql -d SemStew -f database/insert_SemStew_Database.sql -U postgres
-  - psql -c 'ALTER USER postgres WITH PASSWORD \'postolka11\';' -U postgres
+  - psql -c "ALTER USER postgres WITH PASSWORD 'postolka11';" -U postgres
 script: 
 - cd semstew
 - mvn clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - psql -U postgres --list
   - psql -d SemStew -f database/create_SemStew_Database.sql -U postgres
   - psql -d SemStew -f database/insert_SemStew_Database.sql -U postgres
+  - psql -d SemStew -c "\dt+"
   - psql -c "ALTER USER postgres WITH PASSWORD 'postolka11';" -U postgres
 script: 
 - cd semstew

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ services:
   - postgresql
 before_script:
   - psql -c 'CREATE DATABASE SemStew;' -U postgres
-  - psql SemStew -f database/create_SemStew_Database.sql -U postgres
-  - psql SemStew -f database/insert_SemStew_Database.sql -U postgres
+  - psql -U postgres --list
+  - psql -d SemStew -f database/create_SemStew_Database.sql -U postgres
+  - psql -d SemStew -f database/insert_SemStew_Database.sql -U postgres
   - psql -c 'ALTER USER postgres WITH PASSWORD 'postolka11';' -U postgres
 script: 
 - cd semstew

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: java
 jdk: oraclejdk8
 install: true
+services:
+  - postgresql
+before_script:
+  - psql -c 'CREATE DATABASE SemStew;' -U postgres
+  - psql SemStew -f database/create_SemStew_Database.sql -U postgres
+  - psql SemStew -f database/insert_SemStew_Database.sql -U postgres
+  - psql -c 'ALTER USER postgres WITH PASSWORD 'postolka11';' -U postgres
 script: 
 - cd semstew
 - mvn clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - psql -U postgres --list
   - psql -d SemStew -f database/create_SemStew_Database.sql -U postgres
   - psql -d SemStew -f database/insert_SemStew_Database.sql -U postgres
-  - psql -c 'ALTER USER postgres WITH PASSWORD "postolka11";' -U postgres
+  - psql -c 'ALTER USER postgres WITH PASSWORD \'postolka11\';' -U postgres
 script: 
 - cd semstew
 - mvn clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: true
 services:
   - postgresql
 before_script:
-  - psql -c 'CREATE DATABASE SemStew;' -U postgres
+  - psql -c 'CREATE DATABASE "SemStew";' -U postgres
   - psql -U postgres --list
   - psql -d SemStew -f database/create_SemStew_Database.sql -U postgres
   - psql -d SemStew -f database/insert_SemStew_Database.sql -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
   - psql -U postgres --list
   - psql -d SemStew -f database/create_SemStew_Database.sql -U postgres
   - psql -d SemStew -f database/insert_SemStew_Database.sql -U postgres
-  - psql -c 'ALTER USER postgres WITH PASSWORD 'postolka11';' -U postgres
+  - psql -c 'ALTER USER postgres WITH PASSWORD "postolka11";' -U postgres
 script: 
 - cd semstew
 - mvn clean install


### PR DESCRIPTION
Attempt to make Travis builds green again by:

- [x] allowing PostgreSQL on Travis-CI, 
- [x] creating `SemStew` DB,
- [x] running create+insert scripts,
- [x] and changing the password for `postgres` user.